### PR TITLE
Refactor scraper

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,6 @@
+.venv/
+.vscode/
+
+# Ignore everying in the output directory except .gitkeep
+output/*
+!output/.gitkeep

--- a/parse.py
+++ b/parse.py
@@ -1,8 +1,9 @@
-import pandas as pd
-import argh
 import datetime
-import os
 import glob
+import os
+
+import pandas as pd
+
 
 def main():
     today = datetime.date.today()
@@ -103,5 +104,5 @@ def clean_up_money(x):
     no_dollar_sign = x[1:len(x) - 3]
     return no_dollar_sign.replace(',', '')
 
-
-main()
+if __name__ == "__main__":
+    main()

--- a/scrape.py
+++ b/scrape.py
@@ -12,106 +12,104 @@
 #     name: python3
 # ---
 
-# # Scraping for the Philadelphia Bail Bond
-#
-# This code will scrape data from the Philadelphia Courts, cleans the data, and outputs a CSV file. Future implementation is to have it check pages on its own, but for now manual entry of end page is necessary.
-
-# ## Import Libraries
-
-from bs4 import BeautifulSoup
-import requests
-import pandas as pd
-import re
-import argh
-
+import csv
 from datetime import date
+from typing import Dict, Generator, List, Set, Tuple, Union
+
+import argh
+import requests
+from bs4 import BeautifulSoup
+from bs4 import element as BsElement
+
+BASE_URL = "https://www.courts.phila.gov/NewCriminalFilings/date/default.aspx"
 
 
-PAGE_URL = "https://www.courts.phila.gov/NewCriminalFilings/date/default.aspx"
+def get_page(date: str, page: int = 1) -> BeautifulSoup:
+    params: Dict[str, Union[int, str]] = {"search": date, "page": page}
+    response = requests.get(BASE_URL, params=params)
+    response.raise_for_status()
+    return BeautifulSoup(response.content, "html.parser")
 
 
-@argh.arg("--record-date", help = "Date of records to parse (must be within last 7 days)")
-@argh.arg("--out", help = "Name of a file for resulting CSV.")
-def main(record_date = None, out = None):
-    """Scrape data from the Philadelphia Courts, clean, and output a CSV file.
+class PageParser:
+    def __init__(self, soup: BeautifulSoup) -> None:
+        self.soup = soup
 
-    """
+    @property
+    def has_next_page(self) -> bool:
+        page_nums = (
+            anchor.text
+            for anchor in self.soup.find("ul", {"class": "pagination"}).find_all("a")
+        )
+        # This is unicode character U+00BB / HTML entity &#187
+        return "»" in page_nums
 
-    if record_date is None:
-        record_date = str(date.today())
+    def parse_filings(self) -> Generator[Dict[str, str], None, None]:
+        """Return a generator of {heading: datum} dicts for each filing"""
 
-    # This list will hold the scraped data from each page
-    scraped_list_per_page = []
-    # The current page is 1 and the end page as of now is 3 (this needs to be manually checked)
-    curr_page_num, end_page = (1,3)
-    # Starting at the current page and stopping at the last page of the website
-    for curr_page_num in range(end_page):
-        # Take the current page number and increament it each iteration
-        curr_page_num = 1 + curr_page_num
-        # The current webpage stores up to 24 criminal files and we are going through each page by updating the page number in the format
-        params = {
-                "search": record_date,
-                "page": curr_page_num
-                }
-        # Then get the HTML file of the page as text
-        source = requests.get(PAGE_URL, params = params).text
-        # Then create a BeautifulSoup object of the text, this makes pulling data out of HTML files easier
-        # To learn more about it read here (https://www.crummy.com/software/BeautifulSoup/bs4/doc/)
-        soup = BeautifulSoup(source)
-        # After inspecting the source code I noticed the criminal files were listed under this specific div tag
-        # The findAll function will grab each criminal file from that page
-        list_of_criminal_filings = soup.findAll("div", {"class": "well well-sm"})
-        # Then pass the list of all criminal fiilings into the extract_attributes function
-        # After the extract_attributes function completes it will return a list of that whole page's scraped criminal
-        # filings and then it will continue to the next page and at the end we will have one complete joined list
-        scraped_list_per_page = (extract_attributes(list_of_criminal_filings)) + scraped_list_per_page
-    # The joined list will then be passed into the create_csv function and converted to CSV
-    create_csv(out, scraped_list_per_page)
+        for filing in self.soup.find_all("div", {"class": "well well-sm"}):
+            yield {header: data for header, data in self._parse_filing(filing)}
 
-def extract_attributes(list_of_criminal_filings):
-    list_of_criminal_file_scraped = []
-    # For each criminal file in the list of criminal filings pass it into the scrape_and_store function
-    # Then afterwards return everything to main and it will repeat this cycle for the amount of pages
-    for criminal_file in list_of_criminal_filings:
-        criminal_file_scraped = scrape_and_store(criminal_file.text)
-        list_of_criminal_file_scraped.append(criminal_file_scraped)
-    return list_of_criminal_file_scraped
+    def _parse_filing(
+        self, filing: BsElement
+    ) -> Generator[Tuple[str, str], None, None]:
+        """Return a generator of (heading, datum) tuples for a filing
 
-# This is just regex functions that helped me clean the data you can read more about regex here (https://docs.python.org/3/library/re.html)
-def scrape_and_store(text):
-    hold = text.splitlines()
-    defendant_name = re.split('Name (.*?)', hold[3])[-1]
-    age = re.split('Age (.*?)', hold[4])[-1]
-    address = hold[6]
-    city = re.split('\t ', address.split(',')[0])[1]
-    state = re.split(" (.*?) ", re.split(",", address)[1])[1]
-    zip_code = re.split(" (.*?) ", re.split(",", address)[1])[2]
-    docket_number = re.split("Number (.*?)", hold[11])[2]
-    filing = re.split(" ", hold[12])
-    filing_date = filing[2]
-    filing_time = " ".join(filing[3:5])
-    charge = re.split("Charge ", hold[13])[1]
-    represented = hold[15].strip()
-    in_custody = hold[16]
-    if len(in_custody) != 1:
-        try:
-            in_custody = re.split("Custody (.*?)", in_custody)[2]
-        except IndexError as error:
-            in_custody = ""
-    bail_status = re.split("\t(.*?)", hold[-10])[-1]
-    bail_datetime = re.split(" ", hold[-9])
-    bail_date = bail_datetime[2]
-    bail_time = " ".join(bail_datetime[3:5])
-    bail_type = re.split(": (.*?)", hold[-8])[-1]
-    bail_amount = re.split(": (.*?)", hold[-7])[-1]
-    outstanding_bail_amt = re.split(" ", hold[-6])[-1]
-    # Return a list of all the attributes
-    return [defendant_name, age, city, state, zip_code, docket_number, filing_date, filing_time, charge, represented, in_custody, bail_status, bail_date, bail_time, bail_type, bail_amount, outstanding_bail_amt]
+        Each filing in a div.well.well-sm tag, data is split into three p
+        tags which map to the 3 columns of data on the page. Beautiful Soup can
+        handle these p tags easily, but the HTML contained within doesn't lend
+        itself to clean parsing.
+        """
+        for column in filing.find_all("p"):
+            headers = [
+                element.extract().text.strip(":")
+                for element in column.find_all("strong")
+            ]
+            data = [
+                datum for text in column.text.split("\n") if (datum := text.strip())
+            ]
+            for header, datum in zip(headers, data):
+                yield header, datum
 
-# This function will make the list of lists into a CSV file with Pandas
-def create_csv(fname, list_of_criminal_file_scraped):
-    df = pd.DataFrame(list_of_criminal_file_scraped)
-    df.to_csv(fname, index=False, header=["Defendant Name", "Age", "City", "State", "Zip Code", "Docket Number", "Filing Date", "Filing Time", "Charge", "Represented", "In Custody", "Bail Status", "Bail Date", "Bail Time", "Bail Type", "Bail Amount", "Outstanding Bail Amount"])
+
+class Filings:
+    def __init__(self) -> None:
+        self.filings: List[Dict[str, str]] = []
+        self.seen_headers: Set[str] = set()
+
+    def append_filing(self, filing: Dict[str, str]) -> None:
+        self.seen_headers = self.seen_headers.union(filing.keys())
+        self.filings.append(filing)
+
+    def to_csv(self, path: str) -> None:
+        with open(path, "w", newline="") as csvfile:
+            writer = csv.DictWriter(csvfile, fieldnames=sorted(self.seen_headers))
+            writer.writeheader()
+            writer.writerows(self.filings)
+
+
+@argh.arg(
+    "--record-date",
+    default=date.today().isoformat(),
+    help="Date of records to parse (must be within last 7 days)",
+)
+@argh.arg("--out", default="output/filings.csv", help="Pathname for resulting CSV.")
+def main(record_date=None, out=None) -> None:
+
+    filings = Filings()
+
+    page_num = 1
+    while True:
+        soup = get_page(record_date, page_num)
+        page = PageParser(soup)
+        for filing in page.parse_filings():
+            filings.append_filing(filing)
+        if not page.has_next_page:
+            break
+        page_num += 1
+
+    filings.to_csv(out)
+
 
 if __name__ == "__main__":
     argh.dispatch_command(main)


### PR DESCRIPTION
This PR refactors the scrape.py module and allows the scraper to not have to rely on manual entry to set the number of pages to scrape

Other changes include:
- separate page parsing and filing collection / output into classes for their separate concerns 
- Use Python's `csv` module rather than `pandas` to write the output csv
- Include type annotations nice-to-have IDE support