### PR TITLE
feat: scripts to migrate data previously scraped by adam

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 .env
 .ipynb
 .html
+
+.ipynb_checkpoints

--- a/analyses/ncf_migration/.gitignore
+++ b/analyses/ncf_migration/.gitignore
@@ -1,0 +1,2 @@
+# Private data
+data_adam/*

--- a/analyses/ncf_migration/0_sensitive_cleaning.Rmd
+++ b/analyses/ncf_migration/0_sensitive_cleaning.Rmd
@@ -1,0 +1,54 @@
+---
+title: "pbf - data cleaning"
+output: html_document
+---
+
+```{r setup, include=FALSE}
+knitr::opts_chunk$set(echo = TRUE)
+library(tidyverse)
+library(janitor)
+library(digest)
+library(purrr)
+```
+
+```{r, message= FALSE}
+fnames = dir("data_adam", full.names = TRUE)
+deidentified <- 
+  map_df(fnames, read_delim, skip = 1, delim = ";") %>%
+  clean_names() %>%
+  mutate(id = NA, name = NULL) %>%
+  select(id, everything())
+
+# deidentified <-
+#   read_delim("data/sensitive_raw.csv", skip = 1, delim = ";") %>%
+#   clean_names() %>%
+#   mutate(id = map_chr(name, digest) %>% dense_rank(), name = NULL) %>%
+#   select(id, everything())
+
+# deidentified %>% write_csv("output/0a_deidentified.csv")
+```
+
+
+```{r}
+  
+cleaned <-
+  deidentified %>%
+  mutate_at(vars(ends_with("date")), lubridate::mdy_hms) %>%
+  mutate_at(
+    vars(bail_amount, outstanding_bail_amount),
+    ~ str_extract(., "\\$([0-9,]+)\\.[0-9]{2}") %>% str_remove_all(",|\\$") %>% as.numeric()
+  ) %>%
+  mutate_if(is.character, ~str_trim(., "both"))
+
+# cleaned %>% write_csv("output/0b_cleaned.csv")
+```
+
+
+```{r}
+distinct_dockets <-
+  cleaned %>%
+  distinct(docket_number, .keep_all = TRUE)
+
+distinct_dockets %>%
+  write_csv("data_adam_deidentified.csv")
+```

--- a/analyses/ncf_migration/1a_convert_pbf_analysis.py
+++ b/analyses/ncf_migration/1a_convert_pbf_analysis.py
@@ -1,0 +1,95 @@
+# +
+import pandas as pd
+import dotenv
+
+dotenv.load_dotenv()
+# -
+
+# ## Transforming Original data -> new
+#
+# * rename represented -> represented_by
+# * address split to city, state, zip_code
+# * original missing: bail_date, bail_time, filing_time, in_custody
+# * new data missing: id column (for anonymizing; fine to exclude)
+#
+# overlapping data: July 1, July 6, July 7
+
+df_orig = pd.read_csv("https://raw.githubusercontent.com/CodeForPhilly/pbf-analysis/master/Data/0c_distinct_dockets.csv")
+
+# +
+from sqlalchemy import create_engine
+import os
+
+config = {
+    "AWS_ACCESS_KEY_ID": os.environ["AWS_ACCESS_KEY_ID"],
+    "AWS_SECRET_ACCESS_KEY": os.environ["AWS_SECRET_ACCESS_KEY"],
+    "REGION_NAME": os.environ["REGION_NAME"],
+    "SCHEMA_NAME": os.environ["SCHEMA_NAME"],
+    "S3_STAGING_DIR": os.environ["S3_STAGING_DIR"],
+         }
+conn_str = "awsathena+rest://{AWS_ACCESS_KEY_ID}:{AWS_SECRET_ACCESS_KEY}@athena.{REGION_NAME}.amazonaws.com:443/"\
+           "{SCHEMA_NAME}?s3_staging_dir={S3_STAGING_DIR}".format(**config)
+engine = create_engine(conn_str)
+# -
+
+df_new = pd.read_sql("""
+SELECT *
+FROM new_criminal_filings
+""", engine)
+
+set(df_new.columns) - set(df_orig.columns)
+
+set(df_orig.columns) - set(df_new.columns)
+
+# ### Extract city, state, zipcode
+
+# +
+# Regex over address like: Philadelphia, PA 19141
+# However, sometimes the zipcode is missing: Philadelphia, PA
+# Also note, zipcode may have form 191120004 (no hyphens)
+address = df_orig.address.str.extract("(.*?), ([A-Z]+) ?([0-9]+)?")
+df_orig[["city", "state", "zip_code"]] = address
+
+#df_orig[["address", "city", "state", "zip_code"]].head(100)
+# -
+
+# ### Rename represented_by, fill in missing columns as NA
+
+# +
+missing = ['bail_date', 'bail_time', 'in_custody']
+
+out_col_order = ['age',
+ 'city',
+ 'state',
+ 'zip_code',
+ 'docket_number',
+ 'filing_date',
+ 'filing_time',
+ 'charge',
+ 'represented',
+ 'in_custody',
+ 'bail_status',
+ 'bail_date',
+ 'bail_time',
+ 'bail_type',
+ 'bail_amount',
+ 'outstanding_bail_amount']
+
+filing_dt = df_orig.filing_date.astype("datetime64[ns]")
+
+final = (df_orig
+         .rename(columns = {
+             "represented_by": "represented",
+             "bail_status": "bail_type",
+             "bail_type": "bail_status"
+         })
+         .drop(columns = ["id"])
+         .assign(
+             filing_date = filing_dt.dt.strftime("%m/%d/%Y"),
+             filing_time = filing_dt.dt.time,
+             **{k: pd.NA for k in missing}
+         )
+        )
+# -
+
+final[out_col_order].to_csv("output/pbf_analysis_distinct_dockets.csv", index = False)

--- a/analyses/ncf_migration/1b_convert_adam.py
+++ b/analyses/ncf_migration/1b_convert_adam.py
@@ -1,0 +1,57 @@
+import pandas as pd
+df_orig = pd.read_csv("data_adam_deidentified.csv")
+
+# ### Extract city, state, zipcode
+
+# Regex over address like: Philadelphia, PA 19141
+# However, sometimes the zipcode is missing: Philadelphia, PA
+# Also note, zipcode may have form 191120004 (no hyphens)
+address = df_orig.address.str.extract("(.*?), ([A-Z]+) ?([0-9]+)?")
+df_orig[["city", "state", "zip_code"]] = address
+
+# ### Rename represented_by, fill in missing columns as NA
+
+# +
+missing = ['bail_date', 'bail_time', 'in_custody']
+
+out_col_order = ['age',
+ 'city',
+ 'state',
+ 'zip_code',
+ 'docket_number',
+ 'filing_date',
+ 'filing_time',
+ 'charge',
+ 'represented',
+ 'in_custody',
+ 'bail_status',
+ 'bail_date',
+ 'bail_time',
+ 'bail_type',
+ 'bail_amount',
+ 'outstanding_bail_amount']
+
+filing_dt = df_orig.filing_date.astype("datetime64[ns]")
+
+final = (df_orig
+         .rename(columns = {
+             "represented_by": "represented",
+             "bail_status": "bail_type",
+             "bail_type": "bail_status"
+         })
+         .drop(columns = ["id"])
+         # drop a few early days overlapping with pbf-analysis
+         .loc[lambda d: d.filing_date >= "2020-06-17"]
+         # drop a fwe late days overlapping with current scraped data
+         .loc[lambda d: d.filing_date < "2020-07-01"]
+         .assign(
+             filing_date = filing_dt.dt.strftime("%m/%d/%Y"),
+             filing_time = filing_dt.dt.time,
+             **{k: pd.NA for k in missing}
+         )
+        )
+
+
+# -
+
+final.loc[:, out_col_order].to_csv("output/data_adam.csv", index = False)

--- a/analyses/ncf_migration/README.md
+++ b/analyses/ncf_migration/README.md
@@ -1,0 +1,10 @@
+This set of scripts was used to migrate from Adam's original data, to the current parsed format contributed by a volunteer.
+
+## Data
+
+* Data on [pbf-analysis repo][pbf-analysis]: From 2020-02-29 to 2020-06-16
+* `data_adam` folder: sent by Adam Linder. Contains scraped data from 2020-06-15 to 2020-07-07
+* Scraped data on s3: From 2020-07-01 to 2020-09-12 (at time of running this migration)
+
+[pbf-analysis][https://raw.githubusercontent.com/CodeForPhilly/pbf-analysis/master/Data/0c_distinct_dockets.csv]
+


### PR DESCRIPTION
from pairing w/ @chriscardillo

cc @adamrlinder, this adds a folder analyses/ncf_migration, with scripts to process the two previous data sources we had (zipfile sent to Chris, and data up on pbf-analysis) into the format used by the current scraper. Note that Athena lower cases and uses underscores for column names, so we did the same! 