### PR TITLE
Fix divide by zero error

### DIFF
--- a/1a_parse.py
+++ b/1a_parse.py
@@ -41,12 +41,20 @@ def main():
     #Get all where bail was posted
     all_posted = all_cash_bail[all_cash_bail['Bail Status'].fillna("").str.contains('Posted')]
     total_posted = len(all_posted)
-    percentage_posted = int((total_posted / total_cash_bail) * 100)
+
+    if total_cash_bail != 0:
+        percentage_posted = int((total_posted / total_cash_bail) * 100)
+    else:
+        percentage_posted = 0
 
     #Get all with Public Defender
     all_defenders = all_cash_bail[all_cash_bail['Represented'].str.contains('Defender Association', na=False)]
     total_defenders = len(all_defenders)
-    percentage_defenders = int((total_defenders / total_cash_bail) * 100)
+
+    if total_cash_bail != 0:
+        percentage_defenders = int((total_defenders / total_cash_bail) * 100)
+    else:
+        percentage_defenders = 0
 
     #Get just bail amounts
     all_cash_bail_amounts = all_cash_bail['Bail Amount']


### PR DESCRIPTION
On some days there aren't any cases with a bail type of "Monetary" which makes the `total_cash_bail` variable zero, leading to a divide by zero. The github action will fail when this occurs so an email isn't sent for that day? E.g. https://github.com/CodeForPhilly/pbf-scraping/runs/1304561864?check_suite_focus=true