### PR TITLE
Add court summary parsing to download.py; fix docket parsing issues

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -139,3 +139,6 @@ dmypy.json
 # Pyre type checker
 .pyre/
 .Rproj.user
+
+# Temporary-file directories
+analyses/full_dockets/tmp

--- a/analyses/full_dockets/download.py
+++ b/analyses/full_dockets/download.py
@@ -1,37 +1,45 @@
 from selenium import webdriver
 from selenium.webdriver.common.action_chains import ActionChains
-import scrape1
 import requests
 import time
 import os
-import pandas as pd
 import sys
+import pandas as pd
 from sqlalchemy import create_engine
-from funcs_parse import *
-from parse_docket import *
+import parse_docket as docket
+#import parse_court as court
 
 
 def download(docket_link, court_link, docketNumber):
-    #os.system('curl "'+link+'" >> downloads\\'+docketNumber+".pdf")
+    ''' Download, write to PDF, and parse the docket and court summmary 
+        corresponding to a particular docket number and return the parsed docket '''
+        
     dirname = os.path.dirname(__file__)
     dockets_path = os.path.join(dirname, "tmp/dockets/")
     court_path = os.path.join(dirname, "tmp/court/")
     dockets_file = dockets_path + docketNumber+'.pdf'
     court_file   = court_path + docketNumber+'.pdf'
 
+    # Download and parse docket
     r_pdf = requests.get(docket_link, headers={"User-Agent": "ParsingThing"})
     with open(dockets_file, 'wb') as f:
         f.write(r_pdf.content)
-    text = scrape_pdf(dockets_file)
-    parse = parse_pdf(dockets_file, text)
-    print(parse)
+    text_d = docket.scrape_pdf(dockets_file)
+    parse_d = docket.parse_pdf(dockets_file, text_d)
 
+    # Download and parse court summary
     r_pdf = requests.get(court_link, headers={"User-Agent": "ParsingThing"})
     with open(court_file, 'wb') as f:
         f.write(r_pdf.content)
-    return parse
+    #parse_c = court.parse_pdf(court_file) # Need to change parse_court to accept court file
+    
+    return parse_d
+
 
 def fetch_docket_numbers(aws_access_key_id, aws_secret_access_key):
+    ''' Fetch and return list of at most 50 docket numbers from new_criminal_filings
+        in the Athena database '''
+    
     config = {
         "AWS_ACCESS_KEY_ID": aws_access_key_id,
         "AWS_SECRET_ACCESS_KEY": aws_secret_access_key,
@@ -39,73 +47,88 @@ def fetch_docket_numbers(aws_access_key_id, aws_secret_access_key):
         "SCHEMA_NAME": "ncf",
         "S3_STAGING_DIR": "s3://pbf-athena-1/"
     }
-    conn_str = "awsathena+rest://{AWS_ACCESS_KEY_ID}:{AWS_SECRET_ACCESS_KEY}@athena.{REGION_NAME}.amazonaws.com:443/{SCHEMA_NAME}?s3_staging_dir={S3_STAGING_DIR}".format(
+    con_str = "awsathena+rest://{AWS_ACCESS_KEY_ID}:{AWS_SECRET_ACCESS_KEY}@athena.{REGION_NAME}.amazonaws.com:443/{SCHEMA_NAME}?s3_staging_dir={S3_STAGING_DIR}".format(
     **config)
 
-    engine = create_engine(conn_str)
+    engine = create_engine(con_str)
     con = engine.connect()
 
     docket_id_query = 'SELECT DISTINCT A.docket_number FROM new_criminal_filings as A LEFT OUTER JOIN dockets_parsed_raw as B on A.docket_number = B.docket_no WHERE B.docket_no is null LIMIT 50'
     query_result = pd.read_sql(docket_id_query, con)
     docket_list = query_result['docket_number'].to_list()
+    
     return docket_list
 
-def main():
-    docketNumbers = fetch_docket_numbers(str(sys.argv[1]), str(sys.argv[2]))
 
+def main():
+    ''' Fetch all new docket numbers and download, parse, and save .csv for
+        docket and court summary corresponding to each number '''
+    
+    docketNumbers = ['MC-51-CR-0021092-2020']#fetch_docket_numbers(str(sys.argv[1]), str(sys.argv[2]))
     print('docketNumber count: ' + str(len(docketNumbers)))
     print(docketNumbers)
+    
+    # Initialize web driver
     fireFoxOptions = webdriver.FirefoxOptions()
     fireFoxOptions.headless=True
     driver = webdriver.Firefox(options=fireFoxOptions)
     driver.maximize_window()
-    links=[]
-    count=0
+    
+    count = 0
     parsed_results = []
     for item in docketNumbers:
+        # Navigate to docket and court pdf files, then download and parse
         try:
-            if(count%50==0 and count>0):
-                print("\nSleeping for 600 seconds")
+            if (count%50==0 and count>0):
+                print("\nSleeping for 600 seconds... ")
                 time.sleep(600)
                 print("wait complete\n")
 
-            docketNumber=item.split("-")
-            start=time.time()
+            docketNumber = item.split("-")
+            elementBase = "ctl00_ctl00_ctl00_cphMain_cphDynamicContent_cphDynamicContent_docketNumberCriteriaControl"
+            t0 = time.time()
             driver.get("https://ujsportal.pacourts.us/DocketSheets/MC.aspx")
             driver.execute_script("window.scrollTo(0, document.body.scrollHeight);")
-            driver.find_element_by_id("ctl00_ctl00_ctl00_cphMain_cphDynamicContent_cphDynamicContent_docketNumberCriteriaControl_docketNumberControl_mddlCourt" ).send_keys(docketNumber[0])
-            driver.find_element_by_id("ctl00_ctl00_ctl00_cphMain_cphDynamicContent_cphDynamicContent_docketNumberCriteriaControl_docketNumberControl_mtxtCounty").send_keys(docketNumber[1])
-            driver.find_element_by_id("ctl00_ctl00_ctl00_cphMain_cphDynamicContent_cphDynamicContent_docketNumberCriteriaControl_docketNumberControl_mddlDocketType").send_keys(docketNumber[2])
-            driver.find_element_by_id("ctl00_ctl00_ctl00_cphMain_cphDynamicContent_cphDynamicContent_docketNumberCriteriaControl_docketNumberControl_mtxtSequenceNumber").send_keys(docketNumber[3])
-            driver.find_element_by_id("ctl00_ctl00_ctl00_cphMain_cphDynamicContent_cphDynamicContent_docketNumberCriteriaControl_docketNumberControl_mtxtYear").send_keys(docketNumber[4])
-            driver.find_element_by_id("ctl00_ctl00_ctl00_cphMain_cphDynamicContent_cphDynamicContent_docketNumberCriteriaControl_searchCommandControl").click()
-            docketDocument=driver.find_element_by_xpath("/html/body/form/div[3]/div[2]/table/tbody/tr/td/div[2]/div/div[3]/table/tbody/tr/td[1]/div/div/table/tbody/tr[1]/td/table/tbody/tr/td/a")
-            courtSummary=driver.find_element_by_xpath("/html/body/form/div[3]/div[2]/table/tbody/tr/td/div[2]/div/div[3]/table/tbody/tr/td[1]/div/div/table/tbody/tr[2]/td/table/tbody/tr/td/a")
-            hover=ActionChains(driver).move_to_element(driver.find_element_by_xpath("/html/body/form/div[3]/div[2]/table/tbody/tr/td/div[2]/div/div[3]/table/tbody/tr/td[1]/div/table/tbody/tr/td/table/tbody/tr/td/a/img")).move_to_element(docketDocument)
+            driver.find_element_by_id("{0}_docketNumberControl_mddlCourt".format(elementBase)).send_keys(docketNumber[0])
+            driver.find_element_by_id("{0}_docketNumberControl_mtxtCounty".format(elementBase)).send_keys(docketNumber[1])
+            driver.find_element_by_id("{0}_docketNumberControl_mddlDocketType".format(elementBase)).send_keys(docketNumber[2])
+            driver.find_element_by_id("{0}_docketNumberControl_mtxtSequenceNumber".format(elementBase)).send_keys(docketNumber[3])
+            driver.find_element_by_id("{0}_docketNumberControl_mtxtYear".format(elementBase)).send_keys(docketNumber[4])
+            driver.find_element_by_id("{0}_searchCommandControl".format(elementBase)).click()
+            docketDocument = driver.find_element_by_xpath("/html/body/form/div[3]/div[2]/table/tbody/tr/td/div[2]/div/div[3]/table/tbody/tr/td[1]/div/div/table/tbody/tr[1]/td/table/tbody/tr/td/a")
+            courtSummary = driver.find_element_by_xpath("/html/body/form/div[3]/div[2]/table/tbody/tr/td/div[2]/div/div[3]/table/tbody/tr/td[1]/div/div/table/tbody/tr[2]/td/table/tbody/tr/td/a")
+            hover = ActionChains(driver).move_to_element(driver.find_element_by_xpath("/html/body/form/div[3]/div[2]/table/tbody/tr/td/div[2]/div/div[3]/table/tbody/tr/td[1]/div/table/tbody/tr/td/table/tbody/tr/td/a/img")).move_to_element(docketDocument)
             hover.perform()
             count += 1
-            end=time.time()
-            start1=time.time()
+            t1 = time.time()
+            
             data = download(docketDocument.get_attribute("href"),courtSummary.get_attribute("href"),"-".join(docketNumber))
             parsed_results.append(data)
             print('results count: ' + str(len(parsed_results)))
             print('results.last: ' + str(parsed_results[-1]))
-            end1=time.time()
+            t2 = time.time()
+            
             print(count)
             print("-".join(docketNumber))
-            print("selenium time:"+str(end-start))
-            print("download time:" + str(end1- start1))
+            print("selenium time:" + str(t1-t0))
+            print("download time:" + str(t2-t1))
+            
         except Exception as e:
             print("could not download docket:"+"-".join(docketNumber))
             print(e)
 
     driver.close()
+
+    # Save docket data to .csv
     final = pd.DataFrame(parsed_results)
     dirname = os.path.dirname(__file__)
     os.mkdir(os.path.join(dirname, "tmp/parsed_docket_data"))
     filepath = os.path.join(
         dirname, "tmp/parsed_docket_data/docket-data-" + time.strftime("%Y-%m-%d-%H%M%S") + ".csv")
     final.to_csv(filepath, index=False)
+
+    return
+
 
 if __name__=="__main__":
     main()

--- a/analyses/full_dockets/download.py
+++ b/analyses/full_dockets/download.py
@@ -90,30 +90,6 @@ def get_pdf_links(driver, docketstr):
     return docketLink, courtLink
 
 
-def process_docket(docketstr, driver=None):
-    ''' Given a docket number, find, download, scrape, and parse the corresponding 
-        docket and court summary files, returning the parsed data as a dictionary '''
-        
-    if not driver:
-        driver = initialize_web_driver()      
-
-    docketLink, courtLink = get_pdf_links(driver, docketstr)
-    dataDict = download_and_parse(docketLink, courtLink, docketstr)    
-    
-    return dataDict
-    
-
-def initialize_web_driver():
-    ''' Initialize and return the web driver object '''
-    
-    fireFoxOptions = webdriver.FirefoxOptions()
-    fireFoxOptions.headless = True
-    driver = webdriver.Firefox(options=fireFoxOptions)
-    driver.maximize_window()
-    
-    return driver
-
-
 def main():
     ''' Fetch all new docket numbers and download, parse, and save .csv for
         docket and court summary corresponding to each number '''
@@ -122,7 +98,10 @@ def main():
     print('{0} docket numbers found'.format(len(docketList)))
     
     # Initialize web driver
-    driver = initialize_web_driver()   
+    fireFoxOptions = webdriver.FirefoxOptions()
+    fireFoxOptions.headless = True
+    driver = webdriver.Firefox(options=fireFoxOptions)
+    driver.maximize_window()
 
     # Navigate to docket and court pdf files, then download and parse
     parsedData = []
@@ -133,7 +112,8 @@ def main():
             print("wait complete\n")
             
         try:
-            data = process_docket(docketstr, driver=driver)
+            docketLink, courtLink = get_pdf_links(driver, docketstr)
+            data = download_and_parse(docketLink, courtLink, docketstr)  
             if data != {}:
                 parsedData.append(data)
             else:

--- a/analyses/full_dockets/download.py
+++ b/analyses/full_dockets/download.py
@@ -1,13 +1,16 @@
 from selenium import webdriver
 from selenium.webdriver.common.action_chains import ActionChains
+from sqlalchemy import create_engine
 import requests
 import time
 import os
 import sys
 import pandas as pd
-from sqlalchemy import create_engine
 import parse_docket as docket
-#import parse_court as court
+import parse_court as court
+
+DOCKET_BUFFER = 50  # number of dockets before sleep
+SLEEP_TIME = 600    # seconds
 
 
 def download(docket_link, court_link, docketNumber):
@@ -24,6 +27,8 @@ def download(docket_link, court_link, docketNumber):
     r_pdf = requests.get(docket_link, headers={"User-Agent": "ParsingThing"})
     with open(dockets_file, 'wb') as f:
         f.write(r_pdf.content)
+    
+    # TODO: replace with single docket.scrape_and_parse(dockets_file)
     text_d = docket.scrape_pdf(dockets_file)
     parse_d = docket.parse_pdf(dockets_file, text_d)
 
@@ -31,7 +36,9 @@ def download(docket_link, court_link, docketNumber):
     r_pdf = requests.get(court_link, headers={"User-Agent": "ParsingThing"})
     with open(court_file, 'wb') as f:
         f.write(r_pdf.content)
-    #parse_c = court.parse_pdf(court_file) # Need to change parse_court to accept court file
+    #parse_c = court.scrape_and_parse_pdf(court_file) # Need to change parse_court to accept court file
+    
+    # TODO: move court dict entries to docket dict and return full data
     
     return parse_d
 
@@ -60,74 +67,78 @@ def fetch_docket_numbers(aws_access_key_id, aws_secret_access_key):
     return docket_list
 
 
+def get_pdf_links(driver, docketstr):
+    ''' Get docket and court summary pdf file links from website '''
+
+    docketNumber = docketstr.split("-")
+    
+    elementBase = "ctl00_ctl00_ctl00_cphMain_cphDynamicContent_cphDynamicContent_docketNumberCriteriaControl"
+    driver.get("https://ujsportal.pacourts.us/DocketSheets/MC.aspx")
+    driver.execute_script("window.scrollTo(0, document.body.scrollHeight);")
+    driver.find_element_by_id("{0}_docketNumberControl_mddlCourt".format(elementBase)).send_keys(docketNumber[0])
+    driver.find_element_by_id("{0}_docketNumberControl_mtxtCounty".format(elementBase)).send_keys(docketNumber[1])
+    driver.find_element_by_id("{0}_docketNumberControl_mddlDocketType".format(elementBase)).send_keys(docketNumber[2])
+    driver.find_element_by_id("{0}_docketNumberControl_mtxtSequenceNumber".format(elementBase)).send_keys(docketNumber[3])
+    driver.find_element_by_id("{0}_docketNumberControl_mtxtYear".format(elementBase)).send_keys(docketNumber[4])
+    driver.find_element_by_id("{0}_searchCommandControl".format(elementBase)).click()
+    docketDocument = driver.find_element_by_xpath("/html/body/form/div[3]/div[2]/table/tbody/tr/td/div[2]/div/div[3]/table/tbody/tr/td[1]/div/div/table/tbody/tr[1]/td/table/tbody/tr/td/a")
+    courtSummary = driver.find_element_by_xpath("/html/body/form/div[3]/div[2]/table/tbody/tr/td/div[2]/div/div[3]/table/tbody/tr/td[1]/div/div/table/tbody/tr[2]/td/table/tbody/tr/td/a")
+    hover = ActionChains(driver).move_to_element(driver.find_element_by_xpath("/html/body/form/div[3]/div[2]/table/tbody/tr/td/div[2]/div/div[3]/table/tbody/tr/td[1]/div/table/tbody/tr/td/table/tbody/tr/td/a/img")).move_to_element(docketDocument)
+    hover.perform()
+
+    docketLink = docketDocument.get_attribute("href")
+    courtLink = courtSummary.get_attribute("href")
+    
+    return docketLink, courtLink
+
+
 def main():
     ''' Fetch all new docket numbers and download, parse, and save .csv for
         docket and court summary corresponding to each number '''
     
-    docketNumbers = ['MC-51-CR-0021092-2020']#fetch_docket_numbers(str(sys.argv[1]), str(sys.argv[2]))
-    print('docketNumber count: ' + str(len(docketNumbers)))
-    print(docketNumbers)
+    docketList = fetch_docket_numbers(str(sys.argv[1]), str(sys.argv[2]))
+    
+    print('{0} docket numbers found'.format(len(docketList)))
     
     # Initialize web driver
     fireFoxOptions = webdriver.FirefoxOptions()
     fireFoxOptions.headless=True
     driver = webdriver.Firefox(options=fireFoxOptions)
     driver.maximize_window()
-    
-    count = 0
-    parsed_results = []
-    for item in docketNumbers:
-        # Navigate to docket and court pdf files, then download and parse
-        try:
-            if (count%50==0 and count>0):
-                print("\nSleeping for 600 seconds... ")
-                time.sleep(600)
-                print("wait complete\n")
 
-            docketNumber = item.split("-")
-            elementBase = "ctl00_ctl00_ctl00_cphMain_cphDynamicContent_cphDynamicContent_docketNumberCriteriaControl"
-            t0 = time.time()
-            driver.get("https://ujsportal.pacourts.us/DocketSheets/MC.aspx")
-            driver.execute_script("window.scrollTo(0, document.body.scrollHeight);")
-            driver.find_element_by_id("{0}_docketNumberControl_mddlCourt".format(elementBase)).send_keys(docketNumber[0])
-            driver.find_element_by_id("{0}_docketNumberControl_mtxtCounty".format(elementBase)).send_keys(docketNumber[1])
-            driver.find_element_by_id("{0}_docketNumberControl_mddlDocketType".format(elementBase)).send_keys(docketNumber[2])
-            driver.find_element_by_id("{0}_docketNumberControl_mtxtSequenceNumber".format(elementBase)).send_keys(docketNumber[3])
-            driver.find_element_by_id("{0}_docketNumberControl_mtxtYear".format(elementBase)).send_keys(docketNumber[4])
-            driver.find_element_by_id("{0}_searchCommandControl".format(elementBase)).click()
-            docketDocument = driver.find_element_by_xpath("/html/body/form/div[3]/div[2]/table/tbody/tr/td/div[2]/div/div[3]/table/tbody/tr/td[1]/div/div/table/tbody/tr[1]/td/table/tbody/tr/td/a")
-            courtSummary = driver.find_element_by_xpath("/html/body/form/div[3]/div[2]/table/tbody/tr/td/div[2]/div/div[3]/table/tbody/tr/td[1]/div/div/table/tbody/tr[2]/td/table/tbody/tr/td/a")
-            hover = ActionChains(driver).move_to_element(driver.find_element_by_xpath("/html/body/form/div[3]/div[2]/table/tbody/tr/td/div[2]/div/div[3]/table/tbody/tr/td[1]/div/table/tbody/tr/td/table/tbody/tr/td/a/img")).move_to_element(docketDocument)
-            hover.perform()
-            count += 1
-            t1 = time.time()
+    # Navigate to docket and court pdf files, then download and parse
+    parsedData = []
+    for i, docketstr in docketList:
+        if (i%DOCKET_BUFFER==0 and i>0):
+            print("\nSleeping for {0} seconds...".format(SLEEP_TIME))
+            time.sleep(SLEEP_TIME)
+            print("wait complete\n")
             
-            data = download(docketDocument.get_attribute("href"),courtSummary.get_attribute("href"),"-".join(docketNumber))
-            parsed_results.append(data)
-            print('results count: ' + str(len(parsed_results)))
-            print('results.last: ' + str(parsed_results[-1]))
-            t2 = time.time()
-            
-            print(count)
-            print("-".join(docketNumber))
-            print("selenium time:" + str(t1-t0))
-            print("download time:" + str(t2-t1))
+        try:
+            docketLink, courtLink = get_pdf_links(driver, docketstr)
+            data = download(docketLink, courtLink, docketstr)
+            parsedData.append(data)
             
         except Exception as e:
-            print("could not download docket:"+"-".join(docketNumber))
+            print("could not download docket {0}".docketstr)
             print(e)
 
     driver.close()
 
-    # Save docket data to .csv
-    final = pd.DataFrame(parsed_results)
+    # Save all docket and court summary data to .csv
     dirname = os.path.dirname(__file__)
     os.mkdir(os.path.join(dirname, "tmp/parsed_docket_data"))
-    filepath = os.path.join(
-        dirname, "tmp/parsed_docket_data/docket-data-" + time.strftime("%Y-%m-%d-%H%M%S") + ".csv")
+    filename = "tmp/parsed_docket_data/docket-data-{0}.csv".format(time.strftime("%Y-%m-%d-%H%M%S"))
+    filepath = os.path.join(dirname, filename)
+    
+    final = pd.DataFrame(parsedData)
     final.to_csv(filepath, index=False)
 
     return
+
+
+def test_download(testlist=[]):
+    return testlist
 
 
 if __name__=="__main__":

--- a/analyses/full_dockets/download.py
+++ b/analyses/full_dockets/download.py
@@ -7,7 +7,7 @@ import os
 import sys
 import pandas as pd
 import parse_docket as docket
-import parse_court as court
+#import parse_court as court
 
 DOCKET_BUFFER = 50  # number of dockets before sleep
 SLEEP_TIME = 600    # seconds

--- a/analyses/full_dockets/download.py
+++ b/analyses/full_dockets/download.py
@@ -168,5 +168,5 @@ def test_download(testfile='', outfile='download_test'):
 
 
 if __name__=="__main__":
-    #main()
-    test_download()
+    main()
+    #test_download()

--- a/analyses/full_dockets/funcs_parse.py
+++ b/analyses/full_dockets/funcs_parse.py
@@ -1,19 +1,25 @@
-#!/usr/bin/env python3
-# -*- coding: utf-8 -*-
-"""
-Created on Tue Sep 15 19:18:24 2020
-
-@author: bmargalef
-"""
-
 import PyPDF2
 import re
 import numpy as np
 import pdfquery
 
+# Helper functions -----------------------------------------------------------
+def query_contains(page, searchTerm):
+    return 'LTPage[page_index="{}"] LTTextLineHorizontal:contains("{}")'.format(page, searchTerm)
+
+
+def query_box(page, bounds):
+    return 'LTPage[page_index="{}"] LTTextBoxHorizontal:in_bbox("{}, {}, {}, {}")'.format(
+        page, *bounds)
+
+
+def query_line(page, bounds):
+    return 'LTPage[page_index="{}"] LTTextLineHorizontal:in_bbox("{}, {}, {}, {}")'.format(
+        page, *bounds)
+
 
 def find_pages(filename, string):
-    #Find the page numbers where 'string' is found in the pdf
+    """ Return list of page numbers of filename (PDF) in which string is found  """
 
     pdfReader = PyPDF2.PdfFileReader(filename)
     num_pages = pdfReader.numPages
@@ -23,16 +29,18 @@ def find_pages(filename, string):
         Text = PageObj.extractText()
         if re.search(string,Text):
             pages.append(i)
+            
     return pages
 
 
-def offense(pdf,page,y_bottom,y_top, x0, x1,x2,x4,charges,date,statutes, delta = 5):
+def offense(pdf, page, y_bottom, y_top, x0, x1, x2, x4, charges, date, statutes, delta=5):
+    """" TODO: update so that you don't need charges/data/statues for this to run"""
     
-    n_lines = pdf.pq('LTPage[page_index="{}"] LTTextLineHorizontal:in_bbox("{}, {}, {}, {}")'.format(page,0, y_bottom, 80, y_top)).text()
-    n_lines = n_lines.split(' ')
+    
+    n_lines = pdf.pq(query_line(page, [0, y_bottom, 80, y_top])).text().split(' ')
     n = len(n_lines)
     if n_lines[0] == '':
-        charges,date,statutes = charges,date,statutes
+        charges, date, statutes = charges, date, statutes
     else:
         n_offenses =[int(x) for x in n_lines]
         n = len(n_offenses)
@@ -50,14 +58,14 @@ def offense(pdf,page,y_bottom,y_top, x0, x1,x2,x4,charges,date,statutes, delta =
         n_offenses.sort()
         while y > y_bottom:
             y = y-delta
-            info = pdf.pq('LTPage[page_index="{}"] LTTextLineHorizontal:in_bbox("{},{},{},{}")'.format(page,0,y,70,y_top)).text().split(' ')
+            info = pdf.pq(query_line(page, [0, y, 70, y_top])).text().split(' ')
             if len(info[0]) > 0:
                 if int(info[-1]) == n_offenses[k]:
                     y_array_bottom[k-h] = y
                 else:
                     if k <= n-1:
                         k = k+1
-        #k = n_offenses[-1]+h
+
         y = y_bottom
         index = 0
         a = 0
@@ -65,7 +73,7 @@ def offense(pdf,page,y_bottom,y_top, x0, x1,x2,x4,charges,date,statutes, delta =
             if abs(a-1) > len(n_offenses):
                 break
             y = y + delta
-            info = pdf.pq('LTPage[page_index="{}"] LTTextLineHorizontal:in_bbox("{},{},{},{}")'.format(page,0,y_bottom,70,y)).text()   
+            info = pdf.pq(query_line(page, [0, y_bottom, 70, y])).text()   
             info = (re.sub("\s+", ",", info.strip())).split(',')
             if len(info[0]) > 0:
                 if n_offenses[a-1] in [int(x) for x in info]  :
@@ -76,15 +84,17 @@ def offense(pdf,page,y_bottom,y_top, x0, x1,x2,x4,charges,date,statutes, delta =
         y_array_top[0] = y_top
         y_array_bottom[-1] = y_bottom
         for y0, y1 in zip(y_array_bottom,y_array_top):
-            data_charges = pdf.pq('LTPage[page_index="{}"] LTTextLineHorizontal:in_bbox("{}, {}, {}, {}")'.format(page,x0, y0, x1, y1)).text()
+            data_charges = pdf.pq(query_line(page, [x0, y0, x1, y1])).text()
+            data_statutes = pdf.pq(query_line(page, [x4, y0, x0, y1])).text()
+            date = pdf.pq(query_line(page, [x1, y0, x2, y1])).text()
             charges.append(data_charges)
-            data_statutes = pdf.pq('LTPage[page_index="{}"] LTTextLineHorizontal:in_bbox("{}, {}, {}, {}")'.format(page,x4, y0, x0, y1)).text()
             statutes.append(data_statutes)
-            date = pdf.pq('LTPage[page_index="{}"] LTTextLineHorizontal:in_bbox("{}, {}, {}, {}")'.format(page,x1, y0, x2, y1)).text()
-    return charges,date,statutes
 
-def bail_set(pdf,page,y_bottom,y_top, x0, x1,bail,bail_type,delta = 5):
-    n_lines = pdf.pq('LTPage[page_index="{}"] LTTextLineHorizontal:in_bbox("{}, {}, {}, {}")'.format(page,0, y_bottom, 60, y_top)).text().split(' ')
+    return charges, date, statutes
+
+
+def bail_set(pdf, page, y_bottom, y_top, x0, x1, bail, bail_type, delta=5):
+    n_lines = pdf.pq(query_line(page, [0, y_bottom, 60, y_top])).text().split(' ')
     n = len(n_lines)
     y_array_bottom = np.zeros(n)
     y_array_top = np.zeros(n)
@@ -93,7 +103,7 @@ def bail_set(pdf,page,y_bottom,y_top, x0, x1,bail,bail_type,delta = 5):
     new_y_bottom = y_bottom
     while (y < y_top) & (k<=n):
         y = y+delta
-        info = pdf.pq('LTPage[page_index="{}"] LTTextLineHorizontal:in_bbox("{},{},{},{}")'.format(page,0,new_y_bottom,60,y)).text()   
+        info = pdf.pq(query_line(page, [0, new_y_bottom, 60, y])).text()   
         if len(info) > 0:
             if int(info[0]) == int(n_lines[-1-(k-1)]):
                 y_array_top[-1-(k-1)] = y
@@ -110,9 +120,9 @@ def bail_set(pdf,page,y_bottom,y_top, x0, x1,bail,bail_type,delta = 5):
     else:
         bail_other = bail
     for y0, y1 in zip(y_array_bottom,y_array_top):
-        data = pdf.pq('LTPage[page_index="{}"] LTTextLineHorizontal:in_bbox("{}, {}, {}, {}")'.format(page,x0, y0, x1, y1)).text()
-        data_cp = pdf.pq('LTPage[page_index="{}"] LTTextLineHorizontal:in_bbox("{}, {}, {}, {}")'.format(page,0, y0, x0, y1)).text()
-        #bail.append(data)
+        data = pdf.pq(query_line(page, [x0, y0, x1, y1])).text()
+        data_cp = pdf.pq(query_line(page, [0, y0, x0, y1])).text()
+
         if re.search("Bail Set+", data_cp, flags=re.IGNORECASE) :
             bail_set = data
         elif re.search("Bail+", data_cp, flags=re.IGNORECASE) :
@@ -126,76 +136,85 @@ def bail_set(pdf,page,y_bottom,y_top, x0, x1,bail,bail_type,delta = 5):
                 bail_type = 1
     return bail, bail_type
 
-def get_bail_info(pdf,pages):
+
+# Main search functions ------------------------------------------------------
+def get_bail_info(pdf, pages):
     bail_info = []
     for p in pages:
-        info_1 = pdf.pq('LTPage[page_index="{}"] LTTextLineHorizontal:contains("Bail Posting Status")'.format(p))
+        info_1 = pdf.pq(query_contains(p, 'Bail Posting Status'))
         x1_0 = float(info_1.attr('x0'))
         x1_1 = float(info_1.attr('x1'))
         y1_0 = float(info_1.attr('y0'))
-        info_2 = pdf.pq('LTPage[page_index="{}"] LTTextLineHorizontal:contains("Percentage")'.format(p))
+        info_2 = pdf.pq(query_contains(p, 'Percentage'))
         x2_0 = float(info_2.attr('x0'))
         x2_1 = float(info_2.attr('x1'))
-        info_3 = pdf.pq('LTPage[page_index="{}"] LTTextLineHorizontal:contains("CHARGES")'.format(p))
-        if len(info_3) == 0: info_3 = pdf.pq('LTPage[page_index="{}"] LTTextLineHorizontal:contains("CPCMS")'.format(p))
+        info_3 = pdf.pq(query_contains(p, 'CHARGES'))
+        if len(info_3) == 0:
+            info_3 = pdf.pq(query_contains(p, 'CPCMS'))
         y3_1 = float(info_3.attr('y1'))
-        info_4 = pdf.pq('LTPage[page_index="{}"] LTTextLineHorizontal:contains("Bail Action")'.format(p))
+        info_4 = pdf.pq(query_contains(p, 'Bail Action'))
         x4_1 = float(info_4.attr('x1'))
-        info_5 = pdf.pq('LTPage[page_index="{}"] LTTextLineHorizontal:contains("Bail Type")'.format(p))
+        info_5 = pdf.pq(query_contains(p, 'Bail Type'))
         x5_0 = float(info_5.attr('x0'))
-        bail_date = pdf.pq('LTPage[page_index="{}"] LTTextBoxHorizontal:in_bbox("{}, {}, {}, {}")'.format(p,x4_1, y3_1, x5_0, y1_0)).text()
-        bail_type = pdf.pq('LTPage[page_index="{}"] LTTextBoxHorizontal:in_bbox("{}, {}, {}, {}")'.format(p,x5_0, y3_1, x2_0, y1_0)).text()
+        bail_date = pdf.pq(query_box(p, [x4_1, y3_1, x5_0, y1_0])).text()
+        bail_type = pdf.pq(query_box(p, [x5_0, y3_1, x2_0, y1_0])).text()
         bail_date = bail_date.split(' ')[-1]
         bail_type = bail_type.split(' ')[-1]
-        bail_info = pdf.pq('LTPage[page_index="{}"] LTTextBoxHorizontal:in_bbox("{}, {}, {}, {}")'.format(p,x2_1, y3_1, x1_0, y1_0)).text()
+        bail_info = pdf.pq(query_box(p, [x2_1, y3_1, x1_0, y1_0])).text()
         bail_amount = float(bail_info.split('$')[-1].replace(',',''))
         bail_paid = 0
-        check_posted = pdf.pq('LTPage[page_index="{}"] LTTextLineHorizontal:in_bbox("{}, {}, {}, {}")'.format(p,x1_0, y3_1, x1_1, y1_0)).text()
+        check_posted = pdf.pq(query_line(p, [x1_0, y3_1, x1_1, y1_0])).text()
+        
         if 'Posted' in check_posted:
-            bail_paid = bail_amount*0.1
+            bail_paid = 0.1*bail_amount
+
     return bail_amount, bail_paid, bail_date, bail_type 
 
-def get_zip(pdf,page):
-    info_1 = pdf.pq('LTPage[page_index="{}"] LTTextLineHorizontal:contains("Zip: ")'.format(page[0])).text()
+
+def get_zip(pdf, page):
+    info_1 = pdf.pq(query_contains(page[0], 'Zip: ')).text()
     zip_code = info_1.split(' ')[-1]
     regnumber = re.compile(r'\d+')
     if regnumber.search(zip_code) == None:
         zip_code = ''
+
     return zip_code
 
                  
-def get_bail_set(pdf,pages):
+def get_bail_set(pdf, pages):
     bail = []
     bail_type = 1 #0: Bail Set, 1: Other e.g. Bail Posted, changed, denied...
     for p in pages:
-        info_1 = pdf.pq('LTPage[page_index="{}"] LTTextLineHorizontal:contains("Filed By")'.format(p))
+        info_1 = pdf.pq(query_contains(p, 'Filed By'))
         x1_0 = float(info_1.attr('x0'))
         y1_0 = float(info_1.attr('y0'))
-        info_2 = pdf.pq('LTPage[page_index="{}"] LTTextLineHorizontal:contains("CASE FINANCIAL INFORMATION")'.format(p))
-        if len(info_2) == 0: info_2 = pdf.pq('LTPage[page_index="{}"] LTTextLineHorizontal:contains("CPCMS")'.format(p))
+        info_2 = pdf.pq(query_contains(p, 'CASE FINANCIAL INFORMATION'))
+        if len(info_2) == 0:
+            info_2 = pdf.pq(query_contains(p, 'CPCMS'))
         y2_1 = float(info_2.attr('y1'))
         bail,bail_type = bail_set(pdf,p,y2_1,y1_0,x1_0,x1_0+200,bail,bail_type)
+
     return bail
 
 
-def get_charges(pdf,pages):
+def get_charges(pdf, pages):
 
     charges = []
     statutes = []
     date = ''
     for p in pages:
-        info_1 = pdf.pq('LTPage[page_index="{}"] LTTextLineHorizontal:contains("Statute Description")'.format(p))
+        info_1 = pdf.pq(query_contains(p, 'Statute Description'))
         x1_0 = float(info_1.attr('x0'))
         y1_0 = float(info_1.attr('y0'))
-        info_2 = pdf.pq('LTPage[page_index="{}"] LTTextLineHorizontal:contains("DISPOSITION SENTENCING")'.format(p))
-        if len(info_2) == 0: info_2 = pdf.pq('LTPage[page_index="{}"] LTTextLineHorizontal:contains("CPCMS")'.format(p))
+        info_2 = pdf.pq(query_contains(p, 'DISPOSITION SENTENCING'))
+        if len(info_2) == 0:
+            info_2 = pdf.pq(query_contains(p, 'CPCMS'))
         y2_1 = float(info_2.attr('y1'))
-        info_3 = pdf.pq('LTPage[page_index="{}"] LTTextLineHorizontal:contains("Offense Dt")'.format(p))
+        info_3 = pdf.pq(query_contains(p, 'Offense Dt'))
         x3_0 = float(info_3.attr('x0'))
         x3_1 = float(info_3.attr('x1'))+10
-        info_4 = pdf.pq('LTPage[page_index="{}"] LTTextLineHorizontal:contains("Statute")'.format(p))
+        info_4 = pdf.pq(query_contains(p, 'Statute'))
         x4_0 = x1_0 -100 #float(info_4.attr('x0'))
         charges,date, statute = offense(pdf,p,y2_1,y1_0,x1_0,x3_0,x3_1,x4_0,charges,date,statutes)
+
     return charges, date, statute
-
-

--- a/analyses/full_dockets/funcs_parse.py
+++ b/analyses/full_dockets/funcs_parse.py
@@ -30,7 +30,9 @@ def find_pages(filename, string):
 
 
 def offense(pdf, page, y_bottom, y_top, x0, x1, x2, x3, delta=5):
-    """ TODO: update so that you don't need charges/data/statues for this to run """
+    """ Return list of charges, list of statues, and date
+        
+        TODO: try to reduce the amount of code, get rid of magic numbers """
 
     charges = []
     statutes = []
@@ -39,14 +41,8 @@ def offense(pdf, page, y_bottom, y_top, x0, x1, x2, x3, delta=5):
     if lineNums[0] != '':
         n_offenses = [int(x) for x in lineNums]
         nLines = len(n_offenses)
-        h = 0
         
-        if len(charges) > 0:
-            h = 1
-            if charges[0] == '':
-                charges = []
-                statutes = []
-                h = 0
+        h = 0
         y_array_bottom = np.zeros(nLines)
         y_array_top = np.zeros(nLines)
         k = 0

--- a/analyses/full_dockets/parse_court.py
+++ b/analyses/full_dockets/parse_court.py
@@ -4,7 +4,6 @@ import argh
 import pandas as pd
 
 
-
 def scrape_and_parse_pdf(filepath):
     """ Extract race and sex from court summary PDF file.
         Parameters:
@@ -43,15 +42,15 @@ def test_scrape_and_parse(testdir='', outfile='court_summary_test'):
     countAll = 0
     countFailed = 0
     for i, file in enumerate(os.listdir(testdir)):
-        countAll += 1
-        try:
-            print(i)
-            data = scrape_and_parse_pdf(os.path.join(testdir, file))
-            parsedResults.append(data)
-            
-        except:
-            print('Failed: {0}'.format(file))
-            countFailed += 1
+        if (os.path.splitext(file)[1] == '.pdf'):
+            countAll += 1
+            try:
+                print(i)
+                data = scrape_and_parse_pdf(os.path.join(testdir, file))
+                parsedResults.append(data)
+            except:
+                print('Failed: {0}'.format(file))
+                countFailed += 1
     print('{0}/{1} failed'.format(countFailed, countAll))
 
     final = pd.DataFrame(parsedResults)

--- a/analyses/full_dockets/parse_court.py
+++ b/analyses/full_dockets/parse_court.py
@@ -36,25 +36,27 @@ def test_scrape_and_parse(testdir='', outfile='court_summary_test'):
         of dumping into csv for manual checking'''
 
     if testdir == '':
-        testdir = os.path.join(os.path.dirname(__file__),'tmp/court')
+        cwd = os.path.dirname(__file__)
+        testdir = os.path.join(cwd,'tmp/court/')
+        savedir = os.path.join(cwd,'tmp/')
 
-    parsedResults = []
+    parsedSummaries = []
     countAll = 0
     countFailed = 0
     for i, file in enumerate(os.listdir(testdir)):
         if (os.path.splitext(file)[1] == '.pdf'):
             countAll += 1
             try:
-                print(i)
+                print('{0}\t {1}'.format(i, file))
                 data = scrape_and_parse_pdf(os.path.join(testdir, file))
-                parsedResults.append(data)
+                parsedSummaries.append(data)
             except:
                 print('Failed: {0}'.format(file))
                 countFailed += 1
     print('{0}/{1} failed'.format(countFailed, countAll))
 
-    final = pd.DataFrame(parsedResults)
-    final.to_csv(os.path.join(testdir, '{0}.csv'.format(outfile)), index=False)
+    final = pd.DataFrame(parsedSummaries)
+    final.to_csv(os.path.join(savedir, '{0}.csv'.format(outfile)), index=False)
     
 
 if __name__ == "__main__":

--- a/analyses/full_dockets/parse_court.py
+++ b/analyses/full_dockets/parse_court.py
@@ -1,6 +1,6 @@
 import pdfquery
 import os
-import argparse
+import argh
 import pandas as pd
 
 
@@ -26,12 +26,17 @@ def scrape_and_parse_pdf(filepath):
     return parsedData
 
 
-def test_scrape_and_parse(testdir, output_name):
+@argh.arg("--testdir", help="Directory where test files are located")
+@argh.arg("--outfile", help="Filename for output file [outfile].csv")
+def test_scrape_and_parse(testdir='', outfile='court_summary_test'):
     ''' Test scrape_and_parse
     
         TODO: generate test set of pdf:csv pairs and update this function to
         automatically compare the parsed output to the validated output, instead
         of dumping into csv for manual checking'''
+
+    if testdir == '':
+        testdir = os.path.join(os.path.dirname(__file__),'tmp/court')
 
     parsedResults = []
     countAll = 0
@@ -48,16 +53,8 @@ def test_scrape_and_parse(testdir, output_name):
     print('{0}/{1} failed'.format(countFailed, countAll))
 
     final = pd.DataFrame(parsedResults)
-    final.to_csv(output_name+'.csv', index=False)
+    final.to_csv(os.path.join(testdir, '{0}.csv'.format(outfile)), index=False)
     
 
 if __name__ == "__main__":
-    testdir = os.path.join(os.path.dirname(__file__),'tmp/court')
-    parser = argparse.ArgumentParser(description='')
-    parser.add_argument('-p','--path_folder', default=testdir,
-                        help='Path to folder with PDFs')
-    parser.add_argument('-o','--output_name', default='output_court',
-                        help='Path to folder with PDFs')
-
-    args = parser.parse_args()
-    test_scrape_and_parse(args.path_folder,args.output_name)
+    argh.dispatch_command(test_scrape_and_parse)

--- a/analyses/full_dockets/parse_docket.py
+++ b/analyses/full_dockets/parse_docket.py
@@ -100,17 +100,17 @@ def parse_pdf(filename, text):
                      'arresting_officer': r"Arresting Officer :(.*?)Complaint\/Incident"}
     for key, value in parsePatterns.items():
         try:
-            parsedData[key] = re.findall(value, text, re.DOTALL)[0]
+            parsedData[key] = re.findall(value, text, re.DOTALL)[0].strip()
         except:
             print('Warning: could not parse {0}'.format(key))
             parsedData[key] = ''
 
     # Extract some fields using regexp plus further parsing:
     specialPatterns = {'attorney': r"(?<=ATTORNEY INFORMATION Name:)(.*?)(?=\d|Supreme)",
-                     'attorney_type': r"(Public|Private|Court Appointed)",
-                     'prelim':  r"(?<=Calendar Event Type )(.*?)(?=Scheduled)",
-                     'date':    r"\d{2}\/\d{2}\/\d{4}",
-                     'time':    r"((1[0-2]|0?[1-9]):([0-5][0-9]) ?([AaPp][Mm]))"}    
+                       'attorney_type': r"(Public|Private|Court Appointed)",
+                       'prelim':  r"(?<=Calendar Event Type )(.*?)(?=Scheduled)",
+                       'date':    r"\d{2}\/\d{2}\/\d{4}",
+                       'time':    r"((1[0-2]|0?[1-9]):([0-5][0-9]) ?([AaPp][Mm]))"}    
     data_attorney = re.findall(specialPatterns['attorney'], text, re.DOTALL)
     if len(data_attorney) > 0:
         data_attorney = data_attorney[0]
@@ -164,7 +164,7 @@ def test_scrape_and_parse(folder, output_name):
     parsed_results = []
     countAll = 0
     countFailed = 0
-    for i, file in enumerate(os.listdir(folder)):
+    for i, file in enumerate(sorted(os.listdir(folder))):
         countAll += 1
         try:
             print('{0}\t {1}'.format(i, file))

--- a/analyses/full_dockets/parse_docket.py
+++ b/analyses/full_dockets/parse_docket.py
@@ -148,7 +148,7 @@ def parse_pdf(filename, text):
     # Use PDFQuery object to find location on page where the information appears
     parsedData['offenses'],parsedData['offense_date'],parsedData['statute'] = funcs.get_charges(pdfObj, pages_charges)
     parsedData['zip'] = funcs.get_zip(pdfObj, pages_zip)
-    parsedData['bail_set_by'] = funcs.get_bail_set(pdfObj,pages_bail_set)
+    parsedData['bail_set_by'] = funcs.get_magistrate(pdfObj, pages_bail_set)
     parsedData['bail_amount'],parsedData['bail_paid'],parsedData['bail_date'],parsedData['bail_type'] = funcs.get_bail_info(pdfObj, pages_bail_info)
     
     return parsedData
@@ -167,7 +167,7 @@ def test_scrape_and_parse(folder, output_name):
     for i, file in enumerate(os.listdir(folder)):
         countAll += 1
         try:
-            print(i)
+            print('{0}\t {1}'.format(i, file))
             text = scrape_pdf(folder+file)
             if text != '':
                 data = parse_pdf(folder+file,text)


### PR DESCRIPTION
This should resolve issues 37 and 56:

- We now have race and sex data! When `download.py` is run, the CSV that is saved will include race and sex data in the same entry as the docket file information.
- Charge descriptions and statute numbers should no longer be incorrectly concatenated
- Found and addressed an error in parsing charges: if charges appeared on multiple pages, only the last page of charges would be returned. This is now fixed.
- Added test functions to `download.py`, `parse_docket.py`, and `parse_court.py`
- Did some additional refactoring of `download.py`, `funcs_parse.py`, `parse_docket.py`, and `parse_court.py`