### PR TITLE
Remove unused glob import

### DIFF
--- a/1a_parse.py
+++ b/1a_parse.py
@@ -2,7 +2,6 @@ import pandas as pd
 import argh
 import datetime
 import os
-import glob
 import sys
 
 def main():

--- a/requirements.txt
+++ b/requirements.txt
@@ -20,7 +20,6 @@ descartes==1.1.0
 docutils==0.15.2
 entrypoints==0.3
 future==0.18.2
-glob3==0.0.1
 idna==2.10
 importlib-metadata==1.7.0
 ipykernel==5.3.4


### PR DESCRIPTION
The inclusion of glob3 in `requirements.txt` sometimes creates a dependency error. I removed the reference there and in the only place where it was imported, `1a_parse.py`, since it appeared to be unused in that script.