### PR TITLE
Fix attorney parsing issue

### DIFF
--- a/analyses/full_dockets/offense_category.py
+++ b/analyses/full_dockets/offense_category.py
@@ -1,6 +1,5 @@
 # create a dictionary of statute info and offense type 
 # key: (title, chapter)
-import pickle
 
 offense_dict = {}
 ### Unknown statute

--- a/analyses/full_dockets/parse_docket.py
+++ b/analyses/full_dockets/parse_docket.py
@@ -129,26 +129,36 @@ def parse_pdf(filename, text):
             parsedData[key] = ''
 
     # Extract some fields using regexp plus further parsing:
-    specialPatterns = {'attorney': r"(?<=ATTORNEY INFORMATION Name:)(.*?)(?=\d|Supreme)",
+    specialPatterns = {'attorney': r"(?<=ATTORNEY INFORMATION)(.*?)(?=\d|Supreme)",
                        'attorney_type': r"(Public|Private|Court Appointed)"}    
+    badPrefixes = ["Name:", "Philadelphia County District Attorney's Office Prosecutor"]
+    
     data_attorney = re.findall(specialPatterns['attorney'], text, re.DOTALL)
-    if len(data_attorney) > 0:
-        data_attorney = data_attorney[0]
+    if len(data_attorney) > 0: # skips empty space also
+        data_attorney = data_attorney[0].strip()
+
+        for prefix in badPrefixes:
+            if data_attorney.startswith(prefix):
+                data_attorney = data_attorney[len(prefix):].strip()
+            
         attorney_match = re.search(specialPatterns['attorney_type'], data_attorney)
         if attorney_match:
             attorney_type = attorney_match.group(0).strip()
             attorney_information = data_attorney.split(attorney_type)[0].strip()
         else:
-            print('Warning: could not parse {0}'.format('attorney type'))
+            if len(data_attorney) == 0:
+                print("No attorney information listed")
+            else:
+                print('Warning: could not parse {0}'.format('attorney type'))
             attorney_type = ''
             attorney_information = data_attorney.strip()
         parsedData['attorney'] = attorney_information
         parsedData['attorney_type'] = attorney_type
     else:
-        print('Warning: could not parse {0}'.format('attorney'))
+        print('Warning: could not parse attorney')
         parsedData['attorney'] = ''
         parsedData['attorney_type'] = ''
-        
+    
     # Extract remaining fields using pdfquery: 
     # Create PDFQuery object, in addition to given text, for scraping from columns
     pages_charges = funcs.find_pages(filename,'Statute Description')

--- a/analyses/full_dockets/parse_docket.py
+++ b/analyses/full_dockets/parse_docket.py
@@ -146,9 +146,9 @@ def parse_pdf(filename, text):
             attorney_type = attorney_match.group(0).strip()
             attorney_information = data_attorney.split(attorney_type)[0].strip()
         else:
-            if len(data_attorney) == 0:
-                print("No attorney information listed")
-            else:
+            if len(data_attorney) != 0:
+                # In some cases, no attorney information is listed (len(data_attorney) == 0)
+                # but in that case no warning should be raised
                 print('Warning: could not parse {0}'.format('attorney type'))
             attorney_type = ''
             attorney_information = data_attorney.strip()


### PR DESCRIPTION
@adamrlinder reported seeing many attorney or attorney type warnings when parsing many dockets. These were due to two issues: 
- Blank attorney field in docket. This was the cause of many "attorney type" warnings. Now no warning is raised
- Regex missed some valid attorney fields. The updated regex should catch nearly all of these