### PR TITLE
Fix scraping bug, add parsing of full bail info

### DIFF
--- a/analyses/full_dockets/download.py
+++ b/analyses/full_dockets/download.py
@@ -80,7 +80,7 @@ def get_pdf_links(docketstr, driver=None):
     driver.get("https://ujsportal.pacourts.us/CaseSearch")
     
     # Execute docket search
-    selector = Select(driver.find_element_by_name("SearchBy"))
+    selector = Select(driver.find_element_by_xpath("//*[@title='Search By']"))
     selector.select_by_visible_text("Docket Number")
     driver.find_element_by_name("DocketNumber").send_keys(docketstr)
     driver.find_element_by_id("btnSearch").click()
@@ -164,7 +164,8 @@ def main(docket='', awsid='', awskey=''):
     # Save docket and court summary data to two .csv files
     dirname = os.path.dirname(__file__)
     tmpdir = "tmp/parsed_docket_data"
-    os.mkdir(os.path.join(dirname, tmpdir))
+    if not os.path.exists(os.path.join(dirname, tmpdir)):
+        os.mkdir(os.path.join(dirname, tmpdir))
     tag = time.strftime("%Y-%m-%d-%H%M%S")
     
     docketName = "{0}/docket-data-{1}.csv".format(tmpdir, tag)

--- a/analyses/full_dockets/parse_docket.py
+++ b/analyses/full_dockets/parse_docket.py
@@ -178,16 +178,25 @@ def parse_pdf(filename, text):
     pdfObj = pdfquery.PDFQuery(filename)
     pdfObj.load(pages)
 
-    # Use PDFQuery object to find location on page where the information appears
+    # Use PDFQuery object to find location on page where the information appears - non-bail info
     parsedData['offenses'], parsedData['offense_date'], parsedData['statute'], parsedData[
         'offense_type'] = funcs.get_charges(pdfObj, pages_charges)
     parsedData['bail_set_by'] = funcs.get_magistrate(pdfObj, pages_bail_set)
-    parsedData['bail_amount'], parsedData['bail_paid'], parsedData['bail_date'], parsedData[
-        'bail_type'] = funcs.get_bail_info(pdfObj, pages_bail_info)
     parsedData['dob'] = funcs.get_dob(pdfObj, pages_dob)
     parsedData['zip'] = funcs.get_zip(pdfObj, pages_zip)
     parsedData['arresting_officer'] = funcs.get_arresting_officer(pdfObj, pages_arresting_officer)
     parsedData['case_status'], parsedData['arrest_dt'] = funcs.get_status(pdfObj, pages_status)
+
+    # Use PDFQuery object to find location on page where the information appears - bail info
+    bail_info_list, bail_posted, bail_posted_date = funcs.get_bail_info(pdfObj, pages_bail_info)
+    first_bail_info = bail_info_list[0]
+    parsedData['bail_date'] = first_bail_info['bail_date']
+    parsedData['bail_type'] = first_bail_info['bail_type']
+    parsedData['bail_percentage'] = first_bail_info['bail_percentage']
+    parsedData['bail_amount'] = first_bail_info['bail_amount']
+    parsedData['bail_paid'] = bail_posted
+    parsedData['bail_paid_date'] = bail_posted_date
+    parsedData['bail_info_list'] = bail_info_list
 
     #CP dockets have a different method of presenting prelim hearing information that is not currently supported by this script.
     if 'CP-51' in filename:


### PR DESCRIPTION
Scraping: Small update to xpath in `get_pdf_links` in `download.py`.

Parsing: Now parses all information in the Bail Information section!
- As a result of changing `get_bail_info` in `funcs_parse.py`, added three new columns to parsed data dictionary returned by `parse_pdf` in `parse_docket.py`:
    - `bail_info_list`: **list of dictionaries** containing data on each row in the bail section (there may be more than one item if bail was modified after the preliminary arraignment), 
    - `bail_percentage` if Monetary bail type,
    - `bail_paid_date` if bail was posted.
- Updated how `bail_paid` is computed: now computed based on the **newest** `bail_amount` and `bail_percentage` values (Previously, computed as 10% of the **oldest** `bail_amount`)

The `bail_info_list` data can be read from a string using `ast.literal_eval`.